### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bam.tech/native-navigation",
-  "version": "0.0.0-development",
+  "version": "1.0.0",
   "description": "Native Navigation for React Native",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
fix cocoapods lint error - complaining for pod version must be greater than 0

We need something more numerical than "0.0.0-development" for version packaged version number, as it's being used in cocoa pod specs.